### PR TITLE
Modified - plant and garden ids to fix delete bug

### DIFF
--- a/assets/scripts/garden-api/api.js
+++ b/assets/scripts/garden-api/api.js
@@ -45,11 +45,11 @@ const showGarden = function () {
   })
 }
 
-const removePlant = function (plant) {
-  console.log('Token:' + app.user.token)
-  console.log('Garden: ' + plant)
+const removePlant = function (garden) {
+  console.log(app.user.token)
+  console.log(garden)
   return $.ajax({
-    url: app.host + '/gardens/' + plant,
+    url: app.host + '/gardens/' + garden,
     method: 'DELETE',
     headers: {
       Authorization: 'Token token=' + app.user.token

--- a/assets/scripts/garden-api/events.js
+++ b/assets/scripts/garden-api/events.js
@@ -47,10 +47,11 @@ const onRemovePlant = function (event) {
   event.preventDefault()
   // console.log('data: ' + data)
   console.log(event.target)
-  const plant = $(event.target).attr('data-id')
+  const plant = $(event.target).attr('data-plant-id')
+  const garden = $(event.target).attri('data-id')
   console.log('plant: ' + plant)
   // const user = app.user.id
-  api.removePlant(plant)
+  api.removePlant(garden)
     .done(ui.removePlantSuccess(plant))
     .fail(ui.removePlantFail)
 }

--- a/index.html
+++ b/index.html
@@ -89,10 +89,10 @@
               <td>
               <form class="add-note" data-id="{{id}}" method="patch">
                 <input name="plantnote" type="text" value="" placeholder="Plant Notes">
-                <button data-id="{{id}}" type="submit" class="add-note-btn btn btn-primary start">Add Note</button>
+                <button data-id="{{id}}" data-plant-id={{plant_id}} type="submit" class="add-note-btn btn btn-primary start">Add Note</button>
               </form>
               </td>
-              <td><button data-id="{{plant_id}}" type="button" class="remove-plant-btn btn btn-primary start">Remove {{name}} From My Garden</button>
+              <td><button data-id="{{id}}" data-plant-id={{plant_id}} type="button" class="remove-plant-btn btn btn-primary start">Remove {{name}} From My Garden</button>
               </td>
             </tr>
             {{/each}}


### PR DESCRIPTION
Realized that the AJAX for delete was sending plant-id not garden-id

*assets/scripts/garden-api/api.js
-- send garden_id as the argument to removePlant
-- added console.log(garden)
-- changed URL

*assets/scripts/garden-api/events.js
-- changed plant and garden variables to corresponding data-ids
-- changed data sent to API to garden_id

*index.html
-- added a data-plant-id to the add-note-btn
-- added a data-plant-id to the remove-plant-btn